### PR TITLE
Fix StorageChunkTest-AddSegmentToChunk expected value

### DIFF
--- a/src/test/storage/chunk_test.cpp
+++ b/src/test/storage/chunk_test.cpp
@@ -29,7 +29,7 @@ TEST_F(StorageChunkTest, AddSegmentToChunk) {
   EXPECT_EQ(chunk.size(), 0);
   chunk.add_segment(int_value_segment);
   chunk.add_segment(string_value_segment);
-  EXPECT_EQ(chunk.size(), 3);
+  EXPECT_EQ(chunk.size(), 2);
 }
 
 TEST_F(StorageChunkTest, AddValuesToChunk) {


### PR DESCRIPTION
Noticed this while implementing sprint 1. 
I assume the expected value should be 2 instead of 3? As we only add two segments to the chunk.

Hope proposing these changes via a PR is ok 😊 